### PR TITLE
Rename functions with unapproved verbs

### DIFF
--- a/src/TrainingDisable.ps1
+++ b/src/TrainingDisable.ps1
@@ -76,7 +76,8 @@ $LogFileExempt = "$LogFileBasePath\LockoutUsers_EXEMPT_$Date.log"
 #========================================================================================================================
 
 # Create a function that pulls the usernames who are training noncompliant from the WebTraining DB
-function WAM-SQLLookup{
+function Invoke-WamSqlQuery {
+    [Alias('WAM-SQLLookup')]
     # Create a new SQL Connection to the server and the Webstraining DB
     $SQLConnection=New-Object System.Data.SqlClient.SqlConnection
     $SQLConnection.ConnectionString='Server=XXXXX\XXXXX;Database=WebTraining;Integrated Security=True'
@@ -187,7 +188,8 @@ function Write-LogEXEMPT {
 #========================================================================================================================
 
 # Function to perform disable action on user account and set AD description.
-function WAM-Disable{
+function Disable-WhatAboutMe {
+    [Alias('WAM-Disable')]
     param([Parameter(Mandatory=$True)][string]$Identity)
         
         # Checks to see if script is set to only generate a report.  $ReportOnly -eq $True will generate all log files, but will NOT disable accounts.
@@ -248,7 +250,9 @@ function WAM-Disable{
 }
 
 # Function to check list of non-compliant users for exemptions and then disable remaining in AD.
-function WAM-ADSearch{
+function Assert-WhatAboutMePolicy {
+    [Alias('WAM-ADSearch')]
+    param()
     # Imports the username list created from function: WAM-SQLLookup
     $LockOutList = Get-Content -Path $LockOutListFile
 
@@ -345,28 +349,20 @@ function WAM-ADSearch{
 #========================================================================================================================
 #                                                    Sequentialization                                                  #
 #========================================================================================================================
-
-function Start-Main {
-    # Write 'BEGIN' line for script logs.
-    Write-Log -Data "********************BEGIN - WAM Training Non-Compliance Lockout - ALL********************"
-    Write-LogVIP -Data "********************BEGIN - WAM Training Non-Compliance Lockout - VIP********************"
-    Write-LogEXEMPT -Data "********************BEGIN - WAM Training Non-Compliance Lockout - EXEMPT********************"
-
-    # Call function to generate list of non-compliant users.
-    WAM-SQLLookup
-
-    # Call function to check exemptions and disable accounts.
-    WAM-ADSearch
-
-    # Write 'END' line for script logs.
-    Write-Log -Data "********************END - WAM Training Non-Compliance Lockout - ALL********************"
-    Write-LogVIP -Data "********************END - WAM Training Non-Compliance Lockout - VIP********************"
-    Write-LogEXEMPT -Data "********************END - WAM Training Non-Compliance Lockout - EXEMPT********************"
-}
-
-#========================================================================================================================
-#                                                     Initialization                                                    #
-#========================================================================================================================
-
 # Start the Script
-Start-Main
+
+# Write 'BEGIN' line for script logs.
+Write-Log -Data "********************BEGIN - WAM Training Non-Compliance Lockout - ALL********************"
+Write-LogVIP -Data "********************BEGIN - WAM Training Non-Compliance Lockout - VIP********************"
+Write-LogEXEMPT -Data "********************BEGIN - WAM Training Non-Compliance Lockout - EXEMPT********************"
+
+# Call function to generate list of non-compliant users.
+WAM-SQLLookup
+
+# Call function to check exemptions and disable accounts.
+WAM-ADSearch
+
+# Write 'END' line for script logs.
+Write-Log -Data "********************END - WAM Training Non-Compliance Lockout - ALL********************"
+Write-LogVIP -Data "********************END - WAM Training Non-Compliance Lockout - VIP********************"
+Write-LogEXEMPT -Data "********************END - WAM Training Non-Compliance Lockout - EXEMPT********************"


### PR DESCRIPTION
Maintain backward-compatibility with Aliases. 

### CHANGE DETAILS
While it is good to get into the habit of using approved verbs, discover-ability isn't the best motivator to help you adopt best practices. You should do it because when your functions eventually make it into a module someone else will use, they will get a **warning** about those verbs when they use it. To anyone who didn't write your module, this is the last thing you want them to see. It doesn't matter that it's a warning you can ignore. They won't actually read it, they just see a wall of text in an offensive color and they look elsewhere for a solution. Or they will write you to tell you about it. Not sure which is worse ;) 

That being said, this is just an example of how you might rename a function you're already using in production. 

### MORE ON FUNCTIONS
You are using functions incorrectly. If you write one (1) function and use it in your script once, you've over-engineered it. If you have a particular block of code that you copy/paste over and over, that should be in a function. It adds a layer of abstraction which simplifies your code up front, but makes maintaining it more complex. It also allows you to fix that function later, **once**, should it be needed. 

I know that you're probably just trying to keep your code tidy using these functions, but there are better ways to do that without the added complexity. If you just want to section off and collapse blocks of code, use the region/endregion tags:

    #Region MyLabel
    # some code whatever ... a bunch of lines
    #endRegion

### JACK of ALL TRAITORS
Functions should not be doing so many things. A good function does one thing well. If you need 3 separate pieces of information don't run 3 commands inside your function. Write 3 more functions to get those things. Then feed those results into parameters of your downstream functions. 

Also use long, descriptive function names, variables too. I was able to figure out what WAM stood for but others may not and you can't assume things when sharing scripts. Aliases are your friends. Use them in parameters as well. 